### PR TITLE
Convert project to minimal Python uv setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# toy01_table_stripper
+
+This is a minimal Python package that demonstrates how to use the `uv` tool for
+managing dependencies and running the application.
+
+## Development
+
+Create a virtual environment and install dependencies using `uv`:
+
+```bash
+uv venv
+uv pip install -e .
+```
+
+Run the command-line interface by piping an HTML file:
+
+```bash
+cat sample.html | toy01-table-stripper
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["uv>=0.1.0"]
+build-backend = "uv.build"
+
+[project]
+name = "toy01_table_stripper"
+version = "0.1.0"
+readme = "README.md"
+authors = [
+    {name = "pathcosmos", email = "lanco.gh@gmail.com"}
+]
+dependencies = []
+requires-python = ">=3.10"
+
+[project.scripts]
+toy01-table-stripper = "toy01_table_stripper.main:main"
+

--- a/toy01_table_stripper/__init__.py
+++ b/toy01_table_stripper/__init__.py
@@ -1,0 +1,20 @@
+"""toy01_table_stripper package."""
+
+__all__ = ["strip_table"]
+
+
+def strip_table(data: str) -> str:
+    """Return the input string without any HTML <table> tags."""
+    result_lines = []
+    in_table = False
+    for line in data.splitlines():
+        if "<table" in line:
+            in_table = True
+            continue
+        if "</table>" in line:
+            in_table = False
+            continue
+        if not in_table:
+            result_lines.append(line)
+    return "\n".join(result_lines)
+

--- a/toy01_table_stripper/main.py
+++ b/toy01_table_stripper/main.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import sys
+from toy01_table_stripper import strip_table
+
+
+def main() -> int:
+    data = sys.stdin.read()
+    print(strip_table(data))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- add Python package with `strip_table` function
- add CLI entrypoint `toy01-table-stripper`
- document `uv` usage in README
- configure `pyproject.toml` with `uv` build backend
- ignore typical Python artifacts

## Testing
- `git status --short`